### PR TITLE
과도한 요청 방지 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "rxjs": "^7.2.0",
         "swagger-ui-express": "^4.4.0",
         "typeorm": "^0.3.7",
+        "uuid": "^8.3.2",
         "winston": "^3.8.1"
       },
       "devDependencies": {
@@ -55,6 +56,7 @@
         "@types/jsonwebtoken": "^8.5.8",
         "@types/node": "^16.0.0",
         "@types/supertest": "^2.0.11",
+        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
         "codecov": "^3.8.3",
@@ -2370,6 +2372,12 @@
       "dependencies": {
         "@types/superagent": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
@@ -12730,6 +12738,12 @@
       "requires": {
         "@types/superagent": "*"
       }
+    },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "@types/yargs": {
       "version": "16.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@nestjs/platform-express": "^8.0.0",
         "@nestjs/platform-socket.io": "^8.4.7",
         "@nestjs/swagger": "^5.0.9",
+        "@nestjs/throttler": "^3.0.0",
         "@nestjs/typeorm": "^8.1.4",
         "@nestjs/websockets": "^8.4.7",
         "@redis/client": "^1.2.0",
@@ -1830,6 +1831,19 @@
         }
       }
     },
+    "node_modules/@nestjs/throttler": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-3.0.0.tgz",
+      "integrity": "sha512-E5aLstJ1a3yZE6AgcN+BgHLiRd8lonR5E4E4I3wzVHRGfgglHQS1sa2zEUuD/pdzLPlbI8pvVDJom8Z2D1oDug==",
+      "dependencies": {
+        "md5": "^2.2.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0",
+        "reflect-metadata": "^0.1.13"
+      }
+    },
     "node_modules/@nestjs/typeorm": {
       "version": "8.1.4",
       "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-8.1.4.tgz",
@@ -3464,6 +3478,14 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -4016,6 +4038,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/crypto-js": {
@@ -5859,6 +5889,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
     "node_modules/is-core-module": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
@@ -7643,6 +7678,16 @@
       "dev": true,
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/media-typer": {
@@ -12206,6 +12251,14 @@
         "tslib": "2.4.0"
       }
     },
+    "@nestjs/throttler": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-3.0.0.tgz",
+      "integrity": "sha512-E5aLstJ1a3yZE6AgcN+BgHLiRd8lonR5E4E4I3wzVHRGfgglHQS1sa2zEUuD/pdzLPlbI8pvVDJom8Z2D1oDug==",
+      "requires": {
+        "md5": "^2.2.1"
+      }
+    },
     "@nestjs/typeorm": {
       "version": "8.1.4",
       "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-8.1.4.tgz",
@@ -13499,6 +13552,11 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
+    },
     "chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -13929,6 +13987,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
     },
     "crypto-js": {
       "version": "4.1.1",
@@ -15299,6 +15362,11 @@
         "binary-extensions": "^2.0.0"
       }
     },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
     "is-core-module": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
@@ -16664,6 +16732,16 @@
       "dev": true,
       "requires": {
         "tmpl": "1.0.5"
+      }
+    },
+    "md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "media-typer": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@nestjs/platform-express": "^8.0.0",
     "@nestjs/platform-socket.io": "^8.4.7",
     "@nestjs/swagger": "^5.0.9",
+    "@nestjs/throttler": "^3.0.0",
     "@nestjs/typeorm": "^8.1.4",
     "@nestjs/websockets": "^8.4.7",
     "@redis/client": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "rxjs": "^7.2.0",
     "swagger-ui-express": "^4.4.0",
     "typeorm": "^0.3.7",
+    "uuid": "^8.3.2",
     "winston": "^3.8.1"
   },
   "lint-staged": {
@@ -75,6 +76,7 @@
     "@types/jsonwebtoken": "^8.5.8",
     "@types/node": "^16.0.0",
     "@types/supertest": "^2.0.11",
+    "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "codecov": "^3.8.3",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { APP_FILTER } from '@nestjs/core';
 import { DatabaseModule } from './database/database.module';
 import { UsersModule } from './users/users.module';
 import { SmsModule } from './sms/sms.module';
+import { ThrottlerModule } from '@nestjs/throttler';
 
 @Module({
   imports: [
@@ -66,7 +67,11 @@ import { SmsModule } from './sms/sms.module';
     SocketModule,
     DatabaseModule.forRoot({ isTest: false }),
     UsersModule,
-    SmsModule
+    SmsModule,
+    ThrottlerModule.forRoot({
+      ttl: process.env.NODE_ENV === 'prod' ? 300 : 60,
+      limit: 3
+    })
   ],
 
   providers: [

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -21,18 +21,24 @@ import { ResponseRequestValidationDto } from './dtos/RequestValidation.response.
 import { RequestValidateNumberDto } from './dtos/ValidateNumber.request.dto';
 import { ResponseValidateNumberDto } from './dtos/ValidateNumber.response.dto';
 import { RegisterTokenGuard } from './guards/RegisterToken.guard';
+import { ThrottlerBehindProxyGuard } from './guards/TrottlerBehindProxy.guard';
 
 @ApiTags('auth')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
+  @UseGuards(ThrottlerBehindProxyGuard)
   @ApiOperation({ summary: '휴대전화번호 인증번호를 요청한다.' })
   @ApiBody({ type: RequestPhoneNumberDto })
   @ApiResponse({
     status: 200,
     description: '요청 성공시',
     type: ResponseRequestValidationDto
+  })
+  @ApiResponse({
+    status: 429,
+    description: '과도한 요청을 보낼시에'
   })
   @Post('message/send')
   async requestPhoneValidationNumber(
@@ -82,6 +88,7 @@ export class AuthController {
     );
   }
 
+  @UseGuards(ThrottlerBehindProxyGuard)
   @ApiOperation({ summary: '슬랙 인증번호를 발송한다 (관리자 용 )' })
   @ApiResponse({
     status: 200,
@@ -91,6 +98,10 @@ export class AuthController {
   @ApiResponse({
     status: 400,
     description: '슬랙에 들어와있는 유저가 아닐때 , 어드민 유저가 아닐 때'
+  })
+  @ApiResponse({
+    status: 429,
+    description: '과도한 요청을 보낼시에'
   })
   @ApiBody({ type: RequestAdminSendValidationNumberDto })
   @Post('/slack/send')

--- a/src/auth/guards/TrottlerBehindProxy.guard.ts
+++ b/src/auth/guards/TrottlerBehindProxy.guard.ts
@@ -1,0 +1,15 @@
+// throttler-behind-proxy.guard.ts
+// 고스락 백엔드 서버는 nginx 뒤에 프록시 형태로 연결되어있기 때문에
+// X-Forwarded-For 헤더값을 통해서
+// 요청한 사람의 원래 ip 주소를 가져와야합니다.
+import { ThrottlerGuard } from '@nestjs/throttler';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ThrottlerBehindProxyGuard extends ThrottlerGuard {
+  protected getTracker(req: Record<string, any>): string {
+    return req.ips.length ? req.ips[0] : req.ip; // individualize IP extraction to meet your own needs
+  }
+}
+
+// app.controller.ts

--- a/src/auth/guards/TrottlerBehindProxy.guard.ts
+++ b/src/auth/guards/TrottlerBehindProxy.guard.ts
@@ -4,11 +4,25 @@
 // 요청한 사람의 원래 ip 주소를 가져와야합니다.
 import { ThrottlerGuard } from '@nestjs/throttler';
 import { Injectable } from '@nestjs/common';
+import { Request } from 'express';
+import { v4 } from 'uuid';
 
 @Injectable()
 export class ThrottlerBehindProxyGuard extends ThrottlerGuard {
-  protected getTracker(req: Record<string, any>): string {
-    return req.ips.length ? req.ips[0] : req.ip; // individualize IP extraction to meet your own needs
+  protected getTracker(req: Request): string {
+    if (process.env.NODE_ENV === 'prod') {
+      const clientProxyIps = req.headers['x-forwarded-for'];
+      if (!clientProxyIps) {
+        return v4();
+      }
+      if (Array.isArray(clientProxyIps)) {
+        return clientProxyIps[0];
+      } else {
+        return clientProxyIps;
+      }
+    } else {
+      return req.ips.length ? req.ips[0] : req.ip; // individualize IP extraction to meet your own needs
+    }
   }
 }
 


### PR DESCRIPTION
## 📝 PR Summary
문자요청, 슬랙인증등 외부 api 를 쓰는 영역에 과도한 요청을 방지 할 수있는 기능을 추가했습니다.

<!-- 기능 추가 관련 제목 -->

#### 🌲 Working Branch
feature/rate-limiting-issue-27
<!-- 예시) hotfix/price_comma -->

#### 🌲 TODOs
고스락 백엔드는 
nginx 뒷단에 프록시로 들어가 있으므로
X-Forwarded-For 헤더를 통해서 해당아이피를 막습니다.
<!-- 예시) 작업내용  -->

### Related Issues
#27 
<!-- 예시)  #1 -->

