### PR TITLE
:hammer: fix(module) : auth, redis module set to global #30  #34

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "ticket-backend-22th",
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -62,6 +62,7 @@ import { ThrottlerModule } from '@nestjs/throttler';
       }),
       inject: [ConfigService]
     }),
+
     QueueModule,
     AuthModule,
     TicketsModule,
@@ -74,6 +75,21 @@ import { ThrottlerModule } from '@nestjs/throttler';
     ThrottlerModule.forRoot({
       ttl: process.env.NODE_ENV === 'prod' ? 300 : 60,
       limit: 3
+    }),
+    RedisModule.forRootAsync({
+      imports: [ConfigModule],
+      useFactory: async (configService: ConfigService) => ({
+        isTest: false,
+        logging: false,
+        redisConnectOption: {
+          url:
+            'redis://' +
+            configService.get('REDIS_HOST') +
+            ':' +
+            configService.get('REDIS_PORT')
+        }
+      }),
+      inject: [ConfigService]
     })
   ],
 

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,4 +1,4 @@
-import { Inject, Logger, Module } from '@nestjs/common';
+import { Global, Inject, Logger, Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from 'src/database/entities/user.entity';
@@ -13,6 +13,7 @@ import { AuthService } from './auth.service';
 import { AccessTokenGuard } from './guards/AccessToken.guard';
 import { RegisterTokenGuard } from './guards/RegisterToken.guard';
 
+@Global()
 @Module({
   imports: [
     SmsModule.forRootAsync({
@@ -23,22 +24,7 @@ import { RegisterTokenGuard } from './guards/RegisterToken.guard';
       inject: [ConfigService]
     }),
     UsersModule,
-    TypeOrmModule.forFeature([User]),
-    RedisModule.forRootAsync({
-      imports: [ConfigModule],
-      useFactory: async (configService: ConfigService) => ({
-        isTest: false,
-        logging: false,
-        redisConnectOption: {
-          url:
-            'redis://' +
-            configService.get('REDIS_HOST') +
-            ':' +
-            configService.get('REDIS_PORT')
-        }
-      }),
-      inject: [ConfigService]
-    })
+    TypeOrmModule.forFeature([User])
   ],
   controllers: [AuthController],
   providers: [

--- a/src/redis/redis.module.ts
+++ b/src/redis/redis.module.ts
@@ -1,5 +1,6 @@
 import {
   DynamicModule,
+  Global,
   Logger,
   LoggerService,
   Module,
@@ -23,6 +24,8 @@ export type RedisClientType = ReturnType<typeof createClient>;
  * 인증 관련 휴대전화번호 저장이나 간단한 캐시등을 사용하는 모듈
  * 2022-07-13 이찬진
  */
+
+@Global()
 @Module({})
 export class RedisModule {
   static forRootAsync(redisAsyncConfig: RedisAsyncConfig): DynamicModule {

--- a/src/slack/slack.service.spec.ts
+++ b/src/slack/slack.service.spec.ts
@@ -6,7 +6,11 @@ import { OrderStatus, TicketStatus } from 'src/common/consts/enum';
 import { Order } from 'src/database/entities/order.entity';
 import { Ticket } from 'src/database/entities/ticket.entity';
 import { User } from 'src/database/entities/user.entity';
-import { ADMIN_CHANNELID, ORDER_CHANNELID } from './config/slack.const';
+import {
+  ADMIN_CHANNELID,
+  BACKEND_CHANNELID,
+  ORDER_CHANNELID
+} from './config/slack.const';
 import { SlackService } from './slack.service';
 
 describe('SlackService', () => {
@@ -58,6 +62,10 @@ describe('SlackService', () => {
         {
           provide: ORDER_CHANNELID,
           useValue: 'C03MKF2JJ4X'
+        },
+        {
+          provide: BACKEND_CHANNELID,
+          useValue: 'C03Q3D1C43C'
         }
       ]
     }).compile();

--- a/src/tickets/tickets.module.ts
+++ b/src/tickets/tickets.module.ts
@@ -13,7 +13,6 @@ import { TicketsService } from './tickets.service';
 @Module({
   imports: [
     TypeOrmModule.forFeature([Ticket]),
-    AuthModule,
     UsersModule //삭제예정
   ],
   providers: [TicketsService, TicketRepository],

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -9,7 +9,7 @@ import { AuthService } from 'src/auth/auth.service';
 import { RedisModule } from 'src/redis/redis.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User]), forwardRef(() => AuthModule)],
+  imports: [TypeOrmModule.forFeature([User])],
   providers: [UsersService, UserRepository],
   exports: [UsersService],
   controllers: [UsersController]


### PR DESCRIPTION
## 📝 PR Summary

인증 , 레지스 모듈을 글로벌로 설정했습니다
각 모듈에서 인증 서비스 가 필요하실때 모듈설정에서 auth 모듈을 import 할 필요가 없습니다,!
#### 🌲 Working Branch

<!-- 예시) hotfix/price_comma -->

#### 🌲 TODOs

<!-- 예시) 작업내용  -->

### Related Issues

#34 
#30 
<!-- 예시)  #1 -->

