### PR TITLE
ticket enum 타입 마이그레이션 진행

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "ticket-backend-22th",
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
@@ -42,7 +41,8 @@
         "redis": "^4.2.0",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
-        "rxjs": "^7.2.0",
+        "rxjs": "^7.5.6",
+        "rxjs-compat": "^6.6.7",
         "swagger-ui-express": "^4.4.0",
         "typeorm": "^0.3.7",
         "uuid": "^8.3.2",
@@ -74,7 +74,7 @@
         "supertest": "^6.1.3",
         "ts-jest": "^27.0.3",
         "ts-loader": "^9.2.3",
-        "ts-node": "^10.0.0",
+        "ts-node": "^10.9.1",
         "tsconfig-paths": "^3.10.1",
         "typescript": "^4.3.5"
       }
@@ -9063,12 +9063,17 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
-      "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
+      "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
+    },
+    "node_modules/rxjs-compat": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.6.7.tgz",
+      "integrity": "sha512-szN4fK+TqBPOFBcBcsR0g2cmTTUF/vaFEOZNuSdfU8/pGFnNmmn2u8SystYXG1QMrjOPBc6XTKHMVfENDf6hHw=="
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -10083,9 +10088,9 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "10.8.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.2.tgz",
-      "integrity": "sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "devOptional": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -17819,12 +17824,17 @@
       }
     },
     "rxjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
-      "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
+      "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
       "requires": {
         "tslib": "^2.1.0"
       }
+    },
+    "rxjs-compat": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.6.7.tgz",
+      "integrity": "sha512-szN4fK+TqBPOFBcBcsR0g2cmTTUF/vaFEOZNuSdfU8/pGFnNmmn2u8SystYXG1QMrjOPBc6XTKHMVfENDf6hHw=="
     },
     "safe-buffer": {
       "version": "5.2.1",
@@ -18580,9 +18590,9 @@
       }
     },
     "ts-node": {
-      "version": "10.8.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.2.tgz",
-      "integrity": "sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "devOptional": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,12 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "prepare": "husky install",
-    "lint-staged": "lint-staged"
+    "lint-staged": "lint-staged",
+    "typeorm": "ts-node ./node_modules/typeorm/cli",
+    "typeorm:run-migrations": "npm run typeorm migration:run -- -d ./src/database/migrations/typeOrm.config.ts",
+    "typeorm:generate-migration": "npm run typeorm -- -d ./src/database/migrations/typeOrm.config.ts migration:generate ./src/database/migrations/$npm_config_name",
+    "typeorm:create-migration": "npm run typeorm -- migration:create ./src/database/migrations/$npm_config_name",
+    "typeorm:revert-migration": "npm run typeorm -- -d ./src/database/migrations/typeOrm.config.ts migration:revert"
   },
   "dependencies": {
     "@nestjs/axios": "^0.1.0",
@@ -93,7 +98,7 @@
     "supertest": "^6.1.3",
     "ts-jest": "^27.0.3",
     "ts-loader": "^9.2.3",
-    "ts-node": "^10.0.0",
+    "ts-node": "^10.9.1",
     "tsconfig-paths": "^3.10.1",
     "typescript": "^4.3.5"
   },

--- a/src/common/consts/enum.ts
+++ b/src/common/consts/enum.ts
@@ -27,7 +27,10 @@ enum OrderStatus {
 
 enum TicketStatus {
   DONE = '입장완료',
-  WAIT = '입장대기'
+  // 원래 WAIT = "입장대기" 였음 ENTERWAIT이라고 생각하면될듯
+  ENTERWAIT = '입금확인',
+  ORDERWAIT = '확인대기',
+  EXPIRE = '기한만료'
 }
 
 enum JWTType {

--- a/src/common/pipes/ticket-status-validation.pipe.ts
+++ b/src/common/pipes/ticket-status-validation.pipe.ts
@@ -3,7 +3,7 @@ import e from 'express';
 import { TicketStatus } from '../consts/enum';
 
 export class TicketStatusValidationPipe implements PipeTransform {
-  readonly StatusOptions = [TicketStatus.DONE, TicketStatus.WAIT];
+  readonly StatusOptions = [TicketStatus.DONE, TicketStatus.ENTERWAIT];
 
   transform(value: any) {
     if (typeof value === 'object') {

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -38,7 +38,7 @@ export class DatabaseModule {
             password: configService.get('POSTGRES_PASSWORD'),
             // database: configService.get('POSTGRES_DB'),
             entities: [__dirname + '/../**/*.entity.{js,ts}'],
-            synchronize: configService.get('NODE_ENV') === 'dev' ? true : false,
+            synchronize: configService.get('NODE_ENV') === false,
             logging: configService.get('NODE_ENV') === 'dev' ? true : false
           })
         })

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -38,7 +38,7 @@ export class DatabaseModule {
             password: configService.get('POSTGRES_PASSWORD'),
             // database: configService.get('POSTGRES_DB'),
             entities: [__dirname + '/../**/*.entity.{js,ts}'],
-            synchronize: configService.get('NODE_ENV') === false,
+            synchronize: configService.get('NODE_ENV') === 'dev' ? true : false,
             logging: configService.get('NODE_ENV') === 'dev' ? true : false
           })
         })

--- a/src/database/entities/comment.entity.ts
+++ b/src/database/entities/comment.entity.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Exclude, Expose, Transform } from 'class-transformer';
-import { Role } from 'src/common/consts/enum';
+import { Role } from '../../common/consts/enum';
 
 import {
   Column,

--- a/src/database/entities/order.entity.ts
+++ b/src/database/entities/order.entity.ts
@@ -1,8 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Expose, Transform, Type } from 'class-transformer';
 import { MaxLength } from 'class-validator';
-import { OrderStatus, OrderDate } from 'src/common/consts/enum';
-import { UserProfileDto } from 'src/common/dtos/user-profile.dto';
+import { OrderStatus, OrderDate } from '../../common/consts/enum';
+import { UserProfileDto } from '../../common/dtos/user-profile.dto';
 import {
   Column,
   CreateDateColumn,

--- a/src/database/entities/ticket.entity.ts
+++ b/src/database/entities/ticket.entity.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Exclude, Expose, Type } from 'class-transformer';
-import { PerformanceDate, TicketStatus } from 'src/common/consts/enum';
+import { PerformanceDate, TicketStatus } from '../../common/consts/enum';
 import {
   AfterLoad,
   BeforeInsert,
@@ -16,7 +16,7 @@ import {
 import { Order } from './order.entity';
 import { User } from './user.entity';
 import { nanoid } from 'nanoid';
-import { UserProfileDto } from 'src/common/dtos/user-profile.dto';
+import { UserProfileDto } from '../../common/dtos/user-profile.dto';
 
 @Entity()
 export class Ticket {
@@ -55,7 +55,7 @@ export class Ticket {
   @Column({
     type: 'enum',
     enum: TicketStatus,
-    default: TicketStatus.WAIT
+    default: TicketStatus.ORDERWAIT
   })
   public status: TicketStatus;
 

--- a/src/database/entities/user.entity.ts
+++ b/src/database/entities/user.entity.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Exclude, Expose } from 'class-transformer';
-import { Role } from 'src/common/consts/enum';
+import { Role } from '../../common/consts/enum';
 import {
   Column,
   CreateDateColumn,

--- a/src/database/migrations/1658837628780-TicketStatusAddEnum.ts
+++ b/src/database/migrations/1658837628780-TicketStatusAddEnum.ts
@@ -1,0 +1,78 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class TicketStatusAddEnum1658837628780 implements MigrationInterface {
+  name = 'TicketStatusAddEnum1658837628780';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "public"."ticket_status_enum" RENAME TO "ticket_status_enum_old"`
+    );
+
+    await queryRunner.query(
+      `CREATE TYPE "public"."ticket_status_enum_migration" AS ENUM('입장완료', '입금확인', '확인대기', '기한만료' ,'입장대기')`
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."ticket_status_enum" AS ENUM('입장완료', '입금확인', '확인대기', '기한만료' )`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ticket" ALTER COLUMN "status" DROP DEFAULT`
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE "ticket" ALTER COLUMN "status" TYPE "public"."ticket_status_enum_migration" USING "status"::"text"::"public"."ticket_status_enum_migration"`
+    );
+    await queryRunner.query(
+      `UPDATE "ticket"
+          SET status = '확인대기'
+          WHERE status = '입장대기' ;`
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE "ticket" ALTER COLUMN "status" TYPE "public"."ticket_status_enum" USING "status"::"text"::"public"."ticket_status_enum"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ticket" ALTER COLUMN "status" SET DEFAULT '확인대기'`
+    );
+
+    await queryRunner.query(`DROP TYPE "public"."ticket_status_enum_old"`);
+    await queryRunner.query(
+      `DROP TYPE "public"."ticket_status_enum_migration"`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."ticket_status_enum_old" AS ENUM('입장완료', '입장대기')`
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."ticket_status_enum_migration" AS ENUM('입장완료', '입금확인', '확인대기', '기한만료' ,'입장대기')`
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE "ticket" ALTER COLUMN "status" DROP DEFAULT`
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE "ticket" ALTER COLUMN "status" TYPE "public"."ticket_status_enum_migration" USING "status"::"text"::"public"."ticket_status_enum_migration"`
+    );
+    await queryRunner.query(
+      `UPDATE "ticket"
+            SET status = '입장대기'
+            WHERE status IN('확인대기', '기한만료' ,'입장대기') ;`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ticket" ALTER COLUMN "status" TYPE "public"."ticket_status_enum_old" USING "status"::"text"::"public"."ticket_status_enum_old"`
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE "ticket" ALTER COLUMN "status" SET DEFAULT '입장대기'`
+    );
+    await queryRunner.query(`DROP TYPE "public"."ticket_status_enum"`);
+    await queryRunner.query(
+      `DROP TYPE "public"."ticket_status_enum_migration"`
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."ticket_status_enum_old" RENAME TO "ticket_status_enum"`
+    );
+  }
+}

--- a/src/database/migrations/1658841312873-TicketUuidToVARCHAR.ts
+++ b/src/database/migrations/1658841312873-TicketUuidToVARCHAR.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class TicketUuidToVARCHAR1658841312873 implements MigrationInterface {
+  name = 'migrations1658841312873';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "ticket" DROP COLUMN "uuid"`);
+    await queryRunner.query(
+      `ALTER TABLE "ticket" ADD "uuid" character varying(14) NOT NULL`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "ticket" DROP COLUMN "uuid"`);
+    await queryRunner.query(
+      `ALTER TABLE "ticket" ADD "uuid" uuid NOT NULL DEFAULT uuid_generate_v4()`
+    );
+  }
+}

--- a/src/database/migrations/typeOrm.config.ts
+++ b/src/database/migrations/typeOrm.config.ts
@@ -1,0 +1,23 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { config } from 'dotenv';
+import { Ticket } from '../entities/ticket.entity';
+import { Order } from '../entities/order.entity';
+import { User } from '../entities/user.entity';
+import { Comment } from '../entities/comment.entity';
+import { TicketStatusAddEnum1658837628780 } from './1658837628780-TicketStatusAddEnum';
+
+config();
+
+const configService = new ConfigService();
+console.log(configService.get('POSTGRES_HOST'));
+export default new DataSource({
+  type: 'postgres',
+  host: configService.get('POSTGRES_HOST'),
+  port: configService.get('POSTGRES_PORT'),
+  username: configService.get('POSTGRES_USER'),
+  password: configService.get('POSTGRES_PASSWORD'),
+  entities: [Ticket, Order, User, Comment],
+  migrations: [TicketStatusAddEnum1658837628780]
+});

--- a/src/database/migrations/typeOrm.config.ts
+++ b/src/database/migrations/typeOrm.config.ts
@@ -7,6 +7,7 @@ import { Order } from '../entities/order.entity';
 import { User } from '../entities/user.entity';
 import { Comment } from '../entities/comment.entity';
 import { TicketStatusAddEnum1658837628780 } from './1658837628780-TicketStatusAddEnum';
+import { TicketUuidToVARCHAR1658841312873 } from './1658841312873-TicketUuidToVARCHAR';
 
 config();
 
@@ -19,5 +20,8 @@ export default new DataSource({
   username: configService.get('POSTGRES_USER'),
   password: configService.get('POSTGRES_PASSWORD'),
   entities: [Ticket, Order, User, Comment],
-  migrations: [TicketStatusAddEnum1658837628780]
+  migrations: [
+    TicketStatusAddEnum1658837628780,
+    TicketUuidToVARCHAR1658841312873
+  ]
 });

--- a/src/database/migrations/typeOrm.config.ts
+++ b/src/database/migrations/typeOrm.config.ts
@@ -7,7 +7,6 @@ import { Order } from '../entities/order.entity';
 import { User } from '../entities/user.entity';
 import { Comment } from '../entities/comment.entity';
 import { TicketStatusAddEnum1658837628780 } from './1658837628780-TicketStatusAddEnum';
-import { TicketUuidToVARCHAR1658841312873 } from './1658841312873-TicketUuidToVARCHAR';
 
 config();
 
@@ -20,8 +19,5 @@ export default new DataSource({
   username: configService.get('POSTGRES_USER'),
   password: configService.get('POSTGRES_PASSWORD'),
   entities: [Ticket, Order, User, Comment],
-  migrations: [
-    TicketStatusAddEnum1658837628780,
-    TicketUuidToVARCHAR1658841312873
-  ]
+  migrations: [TicketStatusAddEnum1658837628780]
 });

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, Injectable, InternalServerErrorException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException
+} from '@nestjs/common';
 import { RequestOrderDto } from 'src/orders/dtos/request-order.dto';
 import { Order } from 'src/database/entities/order.entity';
 import { User } from 'src/database/entities/user.entity';
@@ -13,100 +17,106 @@ import e from 'express';
 
 @Injectable()
 export class OrdersService {
-	constructor(
-		private orderRepository: OrderRepository,
-		private ticketService: TicketsService,
-		private dataSource: DataSource
-	) {}
+  constructor(
+    private orderRepository: OrderRepository,
+    private ticketService: TicketsService,
+    private dataSource: DataSource
+  ) {}
 
+  // 가격 책정 함수 : 단지 가독성을 위해 함수로 뺌
+  getTotalPrice(requestOrderDto: RequestOrderDto): number {
+    const { selection, ticketCount } = requestOrderDto;
+    const pricePerTicket = 3000; // 티켓 한 장 가격
+    const discountForBoth = 1000; // 양일권에 대한 할인 가격
 
-	// 가격 책정 함수 : 단지 가독성을 위해 함수로 뺌
-	getTotalPrice(requestOrderDto: RequestOrderDto): number {
-		const {selection, ticketCount} = requestOrderDto;
-		const pricePerTicket = 3000;   // 티켓 한 장 가격 
-		const discountForBoth = 1000;  // 양일권에 대한 할인 가격
+    let totalPrice = pricePerTicket * ticketCount;
 
-		let totalPrice = pricePerTicket * ticketCount;
+    if (selection === OrderDate.BOTH) {
+      // ticketCount = 양일권 개수
+      totalPrice = totalPrice * 2 - discountForBoth * ticketCount;
+    }
+    return totalPrice;
+  }
 
-		if (selection === OrderDate.BOTH) {
-			// ticketCount = 양일권 개수
-			totalPrice = (totalPrice * 2) - (discountForBoth * ticketCount);
-		}
-		return totalPrice;
-	}
+  /**
+   * selection과 ticketCount를 요청받아서 가격 책정 후 주문을 생성하고,
+   * 해당 주문에 포함되는 모든 티켓을 각각 생성한다.
+   * @param requestOrderDto {selection, ticketCount}
+   * @param user Request User
+   * @returns Order
+   */
+  async createOrder(
+    requestOrderDto: RequestOrderDto,
+    user: User
+  ): Promise<Order> {
+    const { selection, ticketCount } = requestOrderDto;
+    const totalPrice = this.getTotalPrice(requestOrderDto); // 가격 책정
 
-	/**
-	 * selection과 ticketCount를 요청받아서 가격 책정 후 주문을 생성하고,
-	 * 해당 주문에 포함되는 모든 티켓을 각각 생성한다.
-	 * @param requestOrderDto {selection, ticketCount}
-	 * @param user Request User
-	 * @returns Order
-	 */
-	async createOrder(requestOrderDto: RequestOrderDto, user: User): Promise <Order> {
-		const {selection, ticketCount} = requestOrderDto;
-		const totalPrice = this.getTotalPrice(requestOrderDto); // 가격 책정
+    // 양일권일 경우 요청수량 * 2 해서 저장
+    if (selection === OrderDate.BOTH) {
+      requestOrderDto.ticketCount *= 2;
+    }
 
-		// 양일권일 경우 요청수량 * 2 해서 저장
-		if (selection === OrderDate.BOTH) {
-			requestOrderDto.ticketCount *= 2;
-		}
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
 
-		const queryRunner = this.dataSource.createQueryRunner();
-		await queryRunner.connect();
-		await queryRunner.startTransaction();
+    const connectedOrder = getConnectedRepository(
+      OrderRepository,
+      queryRunner,
+      Order
+    );
+    const connectedTicket = getConnectedRepository(
+      TicketRepository,
+      queryRunner,
+      Ticket
+    );
 
-		const connectedOrder = getConnectedRepository(
-			OrderRepository,
-			queryRunner,
-			Order
-		);
-		const connectedTicket = getConnectedRepository(
-			TicketRepository,
-			queryRunner,
-			Ticket
-		);
+    try {
+      // 주문 생성
+      const order = await connectedOrder.createOrder(
+        requestOrderDto,
+        user,
+        totalPrice
+      );
 
-		try {
-			// 주문 생성
-			const order = await connectedOrder.createOrder(requestOrderDto, user, totalPrice);
+      // ticketList에 생성할 티켓을 모두 담은 후 한번에 비동기요청
+      const ticketList: any[] = [];
 
-			// ticketList에 생성할 티켓을 모두 담은 후 한번에 비동기요청
-			const ticketList = new Array;
+      for (let i = 0; i < ticketCount; i++) {
+        if (selection === OrderDate.BOTH || selection === OrderDate.YB) {
+          const createTicketDto = {
+            date: PerformanceDate.YB,
+            order,
+            user
+          };
+          ticketList.push(createTicketDto);
+        }
+        if (selection === OrderDate.BOTH || selection === OrderDate.OB) {
+          const createTicketDto = {
+            date: PerformanceDate.OB,
+            order,
+            user
+          };
+          ticketList.push(createTicketDto);
+        }
+      }
+      await Promise.all(
+        ticketList.map(dto => connectedTicket.createTicket(dto))
+      );
 
-			for (let i = 0; i < ticketCount; i++) {
-				if (selection === OrderDate.BOTH || selection === OrderDate.YB) {
-					const createTicketDto = {
-						date: PerformanceDate.YB,
-						order,
-						user
-					}
-					ticketList.push(createTicketDto);
-				}
-				if (selection === OrderDate.BOTH || selection === OrderDate.OB) {
-					const createTicketDto = {
-						date: PerformanceDate.OB,
-						order,
-						user
-					}
-					ticketList.push(createTicketDto);
-				}
-			}
-			await Promise.all(ticketList.map((dto) => connectedTicket.createTicket(dto)));
+      await queryRunner.commitTransaction();
+      return order;
+    } catch (e) {
+      // 주문 생성 실패시 Error
+      await queryRunner.rollbackTransaction();
+      throw e;
+    } finally {
+      await queryRunner.release();
+    }
+  }
 
-			await queryRunner.commitTransaction();
-			return order;
-
-		} catch (e) {
-			// 주문 생성 실패시 Error
-			await queryRunner.rollbackTransaction();
-			throw e;
-			
-		} finally {
-			await queryRunner.release();
-		}	
-	}
-
-	async findAllByUserId(userId: number): Promise <Order[]> {
-		return await this.orderRepository.findAllByUserId(userId);
-	}
+  async findAllByUserId(userId: number): Promise<Order[]> {
+    return await this.orderRepository.findAllByUserId(userId);
+  }
 }

--- a/src/slack/slack.service.spec.ts
+++ b/src/slack/slack.service.spec.ts
@@ -76,7 +76,12 @@ describe('SlackService', () => {
 
   it('관리자가 티켓의 상태를 변경하면 알림이 가야합니다.', async () => {
     const value = await service.ticketStateChangedByAdminEvent(
-      new SlackTicketStateChangeDto(1, '테스트', TicketStatus.WAIT, '테스트2')
+      new SlackTicketStateChangeDto(
+        1,
+        '테스트',
+        TicketStatus.ENTERWAIT,
+        '테스트2'
+      )
     );
     console.log(value);
     expect(value).toBeDefined();

--- a/src/tickets/tickets.service.ts
+++ b/src/tickets/tickets.service.ts
@@ -125,7 +125,7 @@ export class TicketsService {
       }
 
       // 티켓 상태 오류('입장대기'가 아님)
-      if (ticket.status !== TicketStatus.WAIT) {
+      if (ticket.status !== TicketStatus.ENTERWAIT) {
         const failureResponse = new TicketEntryResponseDto(
           ticket,
           admin.name,


### PR DESCRIPTION
## 📝 PR Summary
ticket enum 타입 마이그레이션 진행
<!-- 기능 추가 관련 제목 -->

#### 🌲 Working Branch

<!-- 예시) hotfix/price_comma -->
refactor/db-migration-ticket-enum
#### 🌲 TODOs

<!-- 예시) 작업내용  -->

티켓 이넘 상태를 추가했습니다.
그리고 프론트 요구에 맞춰서 enum값중 한 값을 수정했습니다
```javascript
enum TicketStatus {
  DONE = '입장완료',
  // 원래 WAIT = "입장대기" 였음 ENTERWAIT이라고 생각하면될듯
  ENTERWAIT = '입금확인',
  ORDERWAIT = '확인대기',
  EXPIRE = '기한만료'
}
```


npm install 하신뒤에
npm run typeorm:run-migrations
하시면 됩니다.

서버 키시면 안되유
db sync true라서 개발단에있는 티켓 지금까지 만든것들 다 날아갈수도

### Related Issues
#58 
<!-- 예시)  #1 -->

