### PR TITLE
🔨  makeInstanceByApiProperty 함수 생성자 대응, 페이지네이션 예시 추가

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -49,11 +49,26 @@ export class AuthController {
   @UseGuards(ThrottlerBehindProxyGuard)
   @ApiOperation({ summary: '휴대전화번호 인증번호를 요청한다.' })
   @ApiBody({ type: RequestPhoneNumberDto })
-  @ApiResponse({
-    status: 200,
-    description: '요청 성공시',
-    type: ResponseRequestValidationDto
-  })
+  @SuccessResponse(HttpStatus.OK, [
+    {
+      model: ResponseRequestValidationDto,
+      overwriteValue: {
+        alreadySingUp: true
+      },
+      exampleDescription:
+        '이미 가입한 사람이 요청번호를 보내면 alreadySingUp 이 true 입니다.',
+      exampleTitle: '인증번호-이미가입한사람'
+    },
+    {
+      model: ResponseRequestValidationDto,
+      overwriteValue: {
+        alreadySingUp: false
+      },
+      exampleDescription:
+        '처음 회원가입한 사람이 요청번호를 보내면 alreadySingUp 이 false 입니다.',
+      exampleTitle: '인증번호-처음회원가입'
+    }
+  ])
   @ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, [
     {
       model: InternalServerErrorException,

--- a/src/common/decorators/ErrorResponse.decorator.ts
+++ b/src/common/decorators/ErrorResponse.decorator.ts
@@ -74,7 +74,9 @@ export const ErrorResponse = (
         );
       }
       const commonErrorInstance =
-        makeInstanceByApiProperty(ErrorCommonResponse);
+        makeInstanceByApiProperty<ErrorCommonResponse<any>>(
+          ErrorCommonResponse
+        );
       commonErrorInstance.error = innerErrorDto;
       return {
         [error.exampleTitle]: {

--- a/src/common/dtos/page/page-meta.dto.ts
+++ b/src/common/dtos/page/page-meta.dto.ts
@@ -3,27 +3,27 @@ import { Expose } from 'class-transformer';
 import { PageMetaDtoParameters } from './page-meta-dto.interface';
 
 export class PageMetaDto {
-  @ApiProperty()
+  @ApiProperty({ description: '페이지 정보입니다.' })
   @Expose()
   readonly page: number;
 
-  @ApiProperty()
+  @ApiProperty({ description: '몇개를 받아가는지 한페이지 당 원소갯수' })
   @Expose()
   readonly take: number;
 
-  @ApiProperty()
+  @ApiProperty({ description: '총 아이템 숫자 ( 검색 조건에 맞는 )' })
   @Expose()
   readonly itemCount: number;
 
-  @ApiProperty()
+  @ApiProperty({ description: '총 페이지 숫자 ( 검색 조건에 맞는 )' })
   @Expose()
   readonly pageCount: number;
 
-  @ApiProperty()
+  @ApiProperty({ description: '이전페이지가 있는지에 대한정보' })
   @Expose()
   readonly hasPreviousPage: boolean;
 
-  @ApiProperty()
+  @ApiProperty({ description: '다음페이지가 있는지에 대한 정보' })
   @Expose()
   readonly hasNextPage: boolean;
 

--- a/src/common/dtos/page/page.dto.ts
+++ b/src/common/dtos/page/page.dto.ts
@@ -5,7 +5,7 @@ import { PageMetaDto } from './page-meta.dto';
 
 export class PageDto<T> {
   @IsArray()
-  @ApiProperty({ isArray: true })
+  @ApiProperty({ type: 'generic', isArray: true })
   @Expose()
   readonly data: T[];
 

--- a/src/common/utils/makeInstanceByApiProperty.ts
+++ b/src/common/utils/makeInstanceByApiProperty.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { ApiPropertyOptions } from '@nestjs/swagger';
-import { plainToClass, plainToInstance } from 'class-transformer';
-import { mergeObjects } from './mergeTwoObj';
 
+// 스웨거 메타데이터 키
 const DECORATORS_PREFIX = 'swagger';
 const API_MODEL_PROPERTIES = `${DECORATORS_PREFIX}/apiModelProperties`;
 const API_MODEL_PROPERTIES_ARRAY = `${DECORATORS_PREFIX}/apiModelPropertiesArray`;
 
+//nest js 에서 사용중인 Type ( 생성자 )객체
 export interface Type<T = any> extends Function {
   new (...args: any[]): T;
 }
@@ -17,6 +17,7 @@ function isObject(value) {
   return value != null && (type == 'object' || type == 'function');
 }
 
+// 기본생성자 함수
 function isFunction(value): value is Function {
   if (!isObject(value)) {
     return false;
@@ -24,12 +25,14 @@ function isFunction(value): value is Function {
   return true;
 }
 
+// () => type 형태의 순환참조로 기술했을때 가져오는 함수
 function isLazyTypeFunc(
   type: Function | Type<unknown>
 ): type is { type: Function } & Function {
   return isFunction(type) && type.name == 'type';
 }
 
+// 원시타입인지 확인
 function isPrimitiveType(
   type:
     | string
@@ -45,6 +48,7 @@ function isPrimitiveType(
   );
 }
 
+// Type 인지 확인하는 커스텀 타입 체커
 function checkType(object: any): object is Type {
   return object;
 }
@@ -52,49 +56,64 @@ function checkType(object: any): object is Type {
 type ApiPropertyOptionsWithFieldName = ApiPropertyOptions & {
   fieldName: string;
 };
+
+/**
+ * 2022 07 29 이찬진  @ImNM
+ * Dto 클래스에 기술하였던 apiProperty 정보를 가져와
+ * 새로운 객체 인스턴스로 만들어 줍니다.
+ * swagger example 에 타입이 아닌 value 즉 인스턴스 형태로 리턴해줘야할 경우가있는데
+ * 이 함수를 이용해서 생성자 와 값 없이 이미 기술한 정보들로
+ * 새로운 객체를 만들 수있습니다.
+ * 만들때 들어가는 정보의 우선순위는 example -> description 순입니다.
+ * @param dtoClass Type 디티오 타입
+ * @param generic 옵셔널 합니다 안주시면 제네릭 안만듭니다. Type 제네릭이 있을경우 제네릭 디티오를 넘겨줍니다.
+ * @returns apiProperty 정보를 통해 만든 객체
+ */
 export function makeInstanceByApiProperty<T>(
   dtoClass: Type,
   generic?: Type
 ): T {
-  //console.log('name', dtoClass);
-
   // 디티오로 생성자를 만들지 않고 해당 타입만 가져옴.
   // 생성자에 인자가 들어간경우 에러가 남.
-
   const mappingDto = {};
 
+  // metadata 에서 apiProperty로 저장했던 필드명들을 불러옴
   const propertiesArray: string[] =
     Reflect.getMetadata(API_MODEL_PROPERTIES_ARRAY, dtoClass.prototype) || [];
 
+  // apiProperty로 적었던 필드명 하나하나의 정보를 가져오기 위함
   const properties: ApiPropertyOptionsWithFieldName[] = propertiesArray.map(
     field => {
+      // :fieldName 형식이라서 앞에 : 를 짤라줌
+      const fieldName = field.substring(1);
+      // 각 필드마다 메타데이터를 가져옴
       const obj = Reflect.getMetadata(
         API_MODEL_PROPERTIES,
         dtoClass.prototype,
-        field.substring(1)
+        fieldName
       );
-      obj.fieldName = field.substring(1);
+      obj.fieldName = fieldName;
       return obj;
     }
   );
-  // console.log('asdfasdfadsfasdfasdfasdfasdfasdfasdfasdf', properties);
 
-  //   dto.
+  //  mappingDto 를 만듬
   for (const property of properties) {
     const propertyType = property.type;
+    // property.type apiproperty에 type 을 기술 않할 수 있으므로 undefiend 체크
     if (propertyType) {
+      // 이건 커스텀임 generic을 위한 커스텀
+      // dto에 T 제네릭으로 들어가는게 있다면 type을 generic 으로 적어주세요
       if (propertyType === 'generic') {
+        // generic으로 만들 추가적인 타입이 있다면
         if (generic) {
-          // dto[property.fieldName] = makeInstanceByApiProperty(
-          //   dto[property.fieldName + 'Type']
-          // );
-          console.log('asdfasdfadsfasdfasdfasdfasdfasdfasdfasdf', properties);
-
+          // array 형이면 [] 안에 담아서 재귀 호출
           if (property.isArray) {
             mappingDto[property.fieldName] = [
               makeInstanceByApiProperty(generic)
             ];
           } else {
+            // {} 형이면 그냥 바로 호출
             mappingDto[property.fieldName] = makeInstanceByApiProperty(generic);
           }
         }
@@ -127,15 +146,10 @@ export function makeInstanceByApiProperty<T>(
         } else {
           mappingDto[property.fieldName] = property.description;
         }
-        // console.log('fiste', propertyType, dto[property.fieldName]);
       } else if (isLazyTypeFunc(propertyType as Function | Type<unknown>)) {
         // type: () => PageMetaDto  형태의 lazy
+        // 익명함수를 실행시켜 안에 Dto 타입을 가져옵니다.
         const constructorType = (propertyType as Function)();
-        // if (propertyType.name === 'type') {
-        // const text = property.example
-        //   ? property.example
-        //   : property.description;
-        // dto[property.fieldName] = '[타입이있습니다 스키마 확인요망]' + text;
         if (property.isArray) {
           mappingDto[property.fieldName] = [
             makeInstanceByApiProperty(constructorType)
@@ -145,9 +159,7 @@ export function makeInstanceByApiProperty<T>(
             makeInstanceByApiProperty(constructorType);
         }
       } else if (checkType(propertyType)) {
-        //lazy import like () => DTO 레이지 인풋은  내가 해결을 못하겠음..
-        // console.log('fiste', propertyType, dto[property.fieldName]);
-
+        //마지막 정상적인 클래스 형태의 타입
         if (property.isArray) {
           mappingDto[property.fieldName] = [
             makeInstanceByApiProperty(propertyType)
@@ -159,12 +171,5 @@ export function makeInstanceByApiProperty<T>(
       }
     }
   }
-  console.log(mappingDto);
-  /* eslint-disable @typescript-eslint/no-explicit-any */
-  // delete (dtoClass as any).constructor;
-  // // delete dtoClass.constructor;
-  // console.log(dtoClass);
-  // const dto = new dtoClass();
-
   return mappingDto as T;
 }

--- a/src/common/utils/makeInstanceByApiProperty.ts
+++ b/src/common/utils/makeInstanceByApiProperty.ts
@@ -1,5 +1,7 @@
+/* eslint-disable @typescript-eslint/ban-types */
 import { ApiPropertyOptions } from '@nestjs/swagger';
 import { plainToClass, plainToInstance } from 'class-transformer';
+import { mergeObjects } from './mergeTwoObj';
 
 const DECORATORS_PREFIX = 'swagger';
 const API_MODEL_PROPERTIES = `${DECORATORS_PREFIX}/apiModelProperties`;
@@ -9,13 +11,30 @@ export interface Type<T = any> extends Function {
   new (...args: any[]): T;
 }
 
+// source form lodash
+function isObject(value) {
+  const type = typeof value;
+  return value != null && (type == 'object' || type == 'function');
+}
+
+function isFunction(value): value is Function {
+  if (!isObject(value)) {
+    return false;
+  }
+  return true;
+}
+
+function isLazyTypeFunc(
+  type: Function | Type<unknown>
+): type is { type: Function } & Function {
+  return isFunction(type) && type.name == 'type';
+}
+
 function isPrimitiveType(
   type:
     | string
-    // eslint-disable-next-line @typescript-eslint/ban-types
     | Function
     | Type<unknown>
-    // eslint-disable-next-line @typescript-eslint/ban-types
     | [Function]
     | Record<string, any>
     | undefined
@@ -33,10 +52,16 @@ function checkType(object: any): object is Type {
 type ApiPropertyOptionsWithFieldName = ApiPropertyOptions & {
   fieldName: string;
 };
-export function makeInstanceByApiProperty(dtoClass: Type, generic?: Type) {
+export function makeInstanceByApiProperty<T>(
+  dtoClass: Type,
+  generic?: Type
+): T {
   //console.log('name', dtoClass);
 
-  const dto = new dtoClass(generic);
+  // 디티오로 생성자를 만들지 않고 해당 타입만 가져옴.
+  // 생성자에 인자가 들어간경우 에러가 남.
+
+  const mappingDto = {};
 
   const propertiesArray: string[] =
     Reflect.getMetadata(API_MODEL_PROPERTIES_ARRAY, dtoClass.prototype) || [];
@@ -57,50 +82,89 @@ export function makeInstanceByApiProperty(dtoClass: Type, generic?: Type) {
   //   dto.
   for (const property of properties) {
     const propertyType = property.type;
+    if (propertyType) {
+      if (propertyType === 'generic') {
+        if (generic) {
+          // dto[property.fieldName] = makeInstanceByApiProperty(
+          //   dto[property.fieldName + 'Type']
+          // );
+          console.log('asdfasdfadsfasdfasdfasdfasdfasdfasdfasdf', properties);
 
-    if (propertyType === 'generic') {
-      if (generic) {
-        dto[property.fieldName] = makeInstanceByApiProperty(
-          dto[property.fieldName + 'Type']
-        );
-      }
-    } else if (propertyType === 'string') {
-      if (typeof property.example !== 'undefined') {
-        dto[property.fieldName] = property.example;
-      } else {
-        dto[property.fieldName] = property.description;
-      }
-      // console.log('fiste', propertyType, property, dto[property.fieldName]);
-    } else if (propertyType === 'number') {
-      if (typeof property.example !== 'undefined') {
-        dto[property.fieldName] = property.example;
-      } else {
-        dto[property.fieldName] = property.description;
-      }
-      // console.log('fiste', propertyType, dto[property.fieldName]);
-    } else if (isPrimitiveType(propertyType)) {
-      //   //console.log('asdfasdfas', propertyType);
-      if (typeof property.example !== 'undefined') {
-        dto[property.fieldName] = property.example;
-      } else {
-        dto[property.fieldName] = property.description;
-      }
-      // console.log('fiste', propertyType, dto[property.fieldName]);
-    } else if (checkType(propertyType)) {
-      //lazy import like () => DTO 레이지 인풋은  내가 해결을 못하겠음..
-      // console.log('fiste', propertyType, dto[property.fieldName]);
-      if (propertyType.name === 'type') {
-        const text = property.example ? property.example : property.description;
-        dto[property.fieldName] = '[타입이있습니다 스키마 확인요망]' + text;
-      } else {
-        if (property.isArray) {
-          dto[property.fieldName] = [makeInstanceByApiProperty(propertyType)];
+          if (property.isArray) {
+            mappingDto[property.fieldName] = [
+              makeInstanceByApiProperty(generic)
+            ];
+          } else {
+            mappingDto[property.fieldName] = makeInstanceByApiProperty(generic);
+          }
+        }
+      } else if (propertyType === 'string') {
+        // 스트링 형태의 enum
+        if (typeof property.example !== 'undefined') {
+          mappingDto[property.fieldName] = property.example;
         } else {
-          dto[property.fieldName] = makeInstanceByApiProperty(propertyType);
+          mappingDto[property.fieldName] = property.description;
+        }
+        console.log(
+          'fiste',
+          propertyType,
+          property,
+          mappingDto[property.fieldName]
+        );
+      } else if (propertyType === 'number') {
+        // 숫자형태의 enum
+        if (typeof property.example !== 'undefined') {
+          mappingDto[property.fieldName] = property.example;
+        } else {
+          mappingDto[property.fieldName] = property.description;
+        }
+        console.log('fiste', propertyType, mappingDto[property.fieldName]);
+      } else if (isPrimitiveType(propertyType)) {
+        // 원시타입 [String, Boolean, Number]
+        console.log('asdfasdfas', propertyType);
+        if (typeof property.example !== 'undefined') {
+          mappingDto[property.fieldName] = property.example;
+        } else {
+          mappingDto[property.fieldName] = property.description;
+        }
+        // console.log('fiste', propertyType, dto[property.fieldName]);
+      } else if (isLazyTypeFunc(propertyType as Function | Type<unknown>)) {
+        // type: () => PageMetaDto  형태의 lazy
+        const constructorType = (propertyType as Function)();
+        // if (propertyType.name === 'type') {
+        // const text = property.example
+        //   ? property.example
+        //   : property.description;
+        // dto[property.fieldName] = '[타입이있습니다 스키마 확인요망]' + text;
+        if (property.isArray) {
+          mappingDto[property.fieldName] = [
+            makeInstanceByApiProperty(constructorType)
+          ];
+        } else {
+          mappingDto[property.fieldName] =
+            makeInstanceByApiProperty(constructorType);
+        }
+      } else if (checkType(propertyType)) {
+        //lazy import like () => DTO 레이지 인풋은  내가 해결을 못하겠음..
+        // console.log('fiste', propertyType, dto[property.fieldName]);
+
+        if (property.isArray) {
+          mappingDto[property.fieldName] = [
+            makeInstanceByApiProperty(propertyType)
+          ];
+        } else {
+          mappingDto[property.fieldName] =
+            makeInstanceByApiProperty(propertyType);
         }
       }
     }
   }
-  return dto;
-  //   //console.log(new propertys.type());
+  console.log(mappingDto);
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  // delete (dtoClass as any).constructor;
+  // // delete dtoClass.constructor;
+  // console.log(dtoClass);
+  // const dto = new dtoClass();
+
+  return mappingDto as T;
 }

--- a/src/database/entities/comment.entity.ts
+++ b/src/database/entities/comment.entity.ts
@@ -48,7 +48,7 @@ export class Comment {
 
   @ApiProperty({
     description: '응원 코멘트 생성 일자',
-    type: Date
+    type: String
   })
   @Expose()
   @CreateDateColumn()

--- a/src/database/entities/order.entity.ts
+++ b/src/database/entities/order.entity.ts
@@ -104,7 +104,7 @@ export class Order {
 
   @ApiProperty({
     description: '주문 생성 일자',
-    type: Date
+    type: String
   })
   @Expose()
   @CreateDateColumn()

--- a/src/database/entities/ticket.entity.ts
+++ b/src/database/entities/ticket.entity.ts
@@ -89,7 +89,7 @@ export class Ticket {
 
   @ApiProperty({
     description: '티켓 생성 일자',
-    type: Date
+    type: String
   })
   @Expose()
   @CreateDateColumn()

--- a/src/database/entities/user.entity.ts
+++ b/src/database/entities/user.entity.ts
@@ -73,7 +73,7 @@ export class User {
 
   @ApiProperty({
     description: '유저 생성 일자',
-    type: Date
+    type: String
   })
   @Expose()
   @CreateDateColumn()

--- a/src/tickets/tickets.controller.ts
+++ b/src/tickets/tickets.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Delete,
   Get,
+  HttpStatus,
   Param,
   Patch,
   Post,
@@ -31,6 +32,8 @@ import { UsersService } from 'src/users/users.service';
 import { TicketsService } from './tickets.service';
 import { TicketFindDto } from './dtos/ticket-find.dto';
 import { UpdateTicketStatusDto } from './dtos/update-ticket-status.dto';
+import { SuccessResponse } from 'src/common/decorators/SuccessResponse.decorator';
+import { PageDto } from 'src/common/dtos/page/page.dto';
 
 @ApiTags('tickets')
 @ApiBearerAuth('accessToken')
@@ -93,7 +96,24 @@ export class TicketsController {
   //   description: '요청 성공시',
   //   type: PageDto<Ticket>
   // })
-  @ApiPaginatedDto({ model: Ticket, description: '페이지네이션' })
+  // @ApiPaginatedDto({ model: Ticket, description: '페이지네이션' })
+  @SuccessResponse(HttpStatus.OK, [
+    {
+      model: PageDto<Ticket>,
+      exampleDescription: '페이지가 끝일때',
+      exampleTitle: '페이지가 끝일때',
+      generic: Ticket,
+      overwriteValue: {
+        meta: { hasNextPage: false }
+      }
+    },
+    {
+      model: PageDto<Ticket>,
+      exampleDescription: '예시',
+      exampleTitle: '예시',
+      generic: Ticket
+    }
+  ])
   @Get('/find')
   @Roles(Role.Admin)
   getTicketsWith(


### PR DESCRIPTION
## 📝 PR Summary

<!-- 기능 추가 관련 제목 -->
 makeInstanceByApiProperty 함수 생성자 대응, 페이지네이션 예시 추가
 - 문제
생성자가 있는 dto일경우 기존방식이
new dto() 를 해버려서 오류가났었습니다.

 - 해결
dto Model을 타입정보로만 활용하고
mappingDto ={} 오브젝트를 활용해서
값만 매핑하는 형식으로 작성했습니다.

추가적으로 페이지네이션도 예시를 추가할수있게 generic을 인자로 더 받습니다.
```javascript

  /**
   * 제네릭 형태가 필요할 때 기술합니다.
   * pageDto<generic> 인경우?
   */
  generic?: Type<any>;

```

```javascript
  @SuccessResponse(HttpStatus.OK, [
    {
      model: PageDto<Ticket>,
      exampleDescription: '페이지가 끝일때',
      exampleTitle: '페이지가 끝일때',
      generic: Ticket,
      overwriteValue: {
        meta: { hasNextPage: false }
      }
    },
    {
      model: PageDto<Ticket>,
      exampleDescription: '예시',
      exampleTitle: '예시',
      generic: Ticket
    }
  ])
  @Get('/find')
  @Roles(Role.Admin)
```


```javascript

@ApiProperty({type : ()=>lazyDto , description : "레이지 디티오")}

```
위형식의 순환참조 를 막기위해서 적었던 레이지 형식도
재귀콜에 포함 시켰습니다.
거의 모든 형식에 대응 가능합니다

#### 🌲 Working Branch

refactor/success-response-decorator
<!-- 예시) hotfix/price_comma -->

#### 🌲 TODOs

<!-- 예시) 작업내용  -->

### Related Issues

<!-- 예시)  #1 -->

