### PR TITLE
Feature/order 주문모듈: 공짜주문으로 변경, 관리자페이지 전체 현황 조회

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ticket-backend-22th",
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {

--- a/src/common/pipes/orderId-validation.pipe.ts
+++ b/src/common/pipes/orderId-validation.pipe.ts
@@ -10,6 +10,6 @@ export class OrderIdValidationPipe implements PipeTransform {
       //body의 요소일 경우
       value.orderId -= 10000;
     }
-	return value;
+    return value;
   }
 }

--- a/src/database/repositories/order.repository.ts
+++ b/src/database/repositories/order.repository.ts
@@ -156,7 +156,7 @@ export class OrderRepository {
       .where({ status: OrderStatus.DONE })
       .andWhere({ isFree: false });
 
-    const income = queryBuilder.getRawOne();
-    return income;
+    const income = await queryBuilder.getRawOne();
+    return income.sum;
   }
 }

--- a/src/database/repositories/order.repository.ts
+++ b/src/database/repositories/order.repository.ts
@@ -1,14 +1,19 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { plainToInstance } from 'class-transformer';
+import { OrderStatus, TicketStatus } from 'src/common/consts/enum';
 import { PageMetaDto } from 'src/common/dtos/page/page-meta.dto';
 import { PageOptionsDto } from 'src/common/dtos/page/page-options.dto';
 import { PageDto } from 'src/common/dtos/page/page.dto';
+import { EnterReportDto } from 'src/orders/dtos/enter-report.dto';
 import { OrderFindDto } from 'src/orders/dtos/order-find.dto';
+import { OrderReportDto } from 'src/orders/dtos/order-report.dto';
 import { RequestOrderDto } from 'src/orders/dtos/request-order.dto';
 import { ResponseOrderListDto } from 'src/orders/dtos/response-orderlist.dto';
+import { TicketReportDto } from 'src/orders/dtos/ticket-report.dto';
 import { Like, Repository } from 'typeorm';
 import { Order } from '../entities/order.entity';
+import { Ticket } from '../entities/ticket.entity';
 import { User } from '../entities/user.entity';
 
 @Injectable()
@@ -113,5 +118,45 @@ export class OrderRepository {
 
   async saveOrder(order: Order): Promise<Order> {
     return await this.orderRepository.save(order);
+  }
+
+  /**
+   *
+   * @returns 주문 입금 관련 현황 (세가지 상태 현황)
+   */
+  async getOrderReport(): Promise<OrderReportDto> {
+    const queryBuilder = this.orderRepository.createQueryBuilder('order');
+
+    queryBuilder.select('order.id');
+
+    const orderReportDto = {
+      totalOrder: await queryBuilder.getCount(),
+      waitOrder: await queryBuilder
+        .where({ status: OrderStatus.WAIT })
+        .getCount(),
+      doneOrder: await queryBuilder
+        .where({ status: OrderStatus.DONE })
+        .getCount(),
+      expireOrder: await queryBuilder
+        .where({ status: OrderStatus.EXPIRE })
+        .getCount()
+    };
+    return orderReportDto;
+  }
+
+  /**
+   *
+   * @returns 입금확인 된 판매대금
+   */
+  async getIncome(): Promise<number> {
+    const queryBuilder = this.orderRepository.createQueryBuilder('order');
+
+    queryBuilder
+      .select('SUM(order.price)', 'sum')
+      .where({ status: OrderStatus.DONE })
+      .andWhere({ isFree: false });
+
+    const income = queryBuilder.getRawOne();
+    return income;
   }
 }

--- a/src/orders/dtos/enter-report.dto.ts
+++ b/src/orders/dtos/enter-report.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { IsNumber } from 'class-validator';
+
+export class EnterReportDto {
+  @ApiProperty({
+    description: '입장 확인된 티켓',
+    type: Number
+  })
+  @IsNumber()
+  @Expose()
+  enteredTicket: number;
+
+  @ApiProperty({
+    description: '입장 확인 안된 티켓',
+    type: Number
+  })
+  @IsNumber()
+  @Expose()
+  nonEnteredTicket: number;
+}

--- a/src/orders/dtos/order-find.dto.ts
+++ b/src/orders/dtos/order-find.dto.ts
@@ -1,6 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
-import { IsBoolean, IsEnum, IsOptional, IsString, MaxLength, Min, MinLength } from 'class-validator';
+import {
+  IsBoolean,
+  IsEnum,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Min,
+  MinLength
+} from 'class-validator';
 import { OrderDate, OrderStatus } from 'src/common/consts/enum';
 
 export class OrderFindDto {

--- a/src/orders/dtos/order-report.dto.ts
+++ b/src/orders/dtos/order-report.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { IsNumber } from 'class-validator';
+
+export class OrderReportDto {
+  // 입금 상태 별 주문 수
+  @ApiProperty({
+    description: '총 주문 수',
+    type: Number
+  })
+  @IsNumber()
+  @Expose()
+  totalOrder: number;
+
+  @ApiProperty({
+    description: '확인대기',
+    type: Number
+  })
+  @IsNumber()
+  @Expose()
+  waitOrder: number;
+
+  @ApiProperty({
+    description: '입금확인',
+    type: Number
+  })
+  @IsNumber()
+  @Expose()
+  doneOrder: number;
+
+  @ApiProperty({
+    description: '기한만료',
+    type: Number
+  })
+  @IsNumber()
+  @Expose()
+  expireOrder: number;
+}

--- a/src/orders/dtos/report.dto.ts
+++ b/src/orders/dtos/report.dto.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { EnterReportDto } from './enter-report.dto';
+import { OrderReportDto } from './order-report.dto';
+import { TicketReportDto } from './ticket-report.dto';
+
+export class ReportDto {
+  @ApiProperty({
+    description: '주문 입금 관련 현황',
+    type: OrderReportDto
+  })
+  @Expose()
+  orderReport: OrderReportDto;
+
+  @ApiProperty({
+    description: '티켓 관련 현황',
+    type: TicketReportDto
+  })
+  @Expose()
+  ticketReport: TicketReportDto;
+
+  @ApiProperty({
+    description: '입장 관련 현황',
+    type: EnterReportDto
+  })
+  @Expose()
+  enterReport: EnterReportDto;
+
+  @ApiProperty({
+    description: '판매 대금',
+    type: Number
+  })
+  @Expose()
+  income: number;
+}

--- a/src/orders/dtos/ticket-report.dto.ts
+++ b/src/orders/dtos/ticket-report.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { IsNumber } from 'class-validator';
+
+export class TicketReportDto {
+  @ApiProperty({
+    description: '링크 발급된 총 티켓 수',
+    type: Number
+  })
+  @IsNumber()
+  @Expose()
+  totalTicket: number;
+
+  @ApiProperty({
+    description: '입금 확인된 티켓',
+    type: Number
+  })
+  @IsNumber()
+  @Expose()
+  depositedTicket: number;
+}

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -35,6 +35,7 @@ import { Role } from 'src/common/consts/enum';
 import { PageOptionsDto } from 'src/common/dtos/page/page-options.dto';
 import { OrderFindDto } from './dtos/order-find.dto';
 import { UpdateOrderStatusDto } from './dtos/update-order-status.dto';
+import { ReportDto } from './dtos/report.dto';
 
 @ApiTags('orders')
 @ApiBearerAuth('accessToken')
@@ -103,26 +104,6 @@ export class OrdersController {
   }
 
   @ApiOperation({
-    summary: '해당 주문에 속한 티켓 목록을 불러온다'
-  })
-  @ApiResponse({
-    status: 200,
-    description: '요청 성공시',
-    type: Ticket,
-    isArray: true
-  })
-  @ApiUnauthorizedResponse({
-    status: 401,
-    description: 'AccessToken이 없을 경우'
-  })
-  @Get('/:orderId')
-  getTicketListByOrderId(
-    @Param('orderId', OrderIdValidationPipe) orderId: number
-  ): Promise<Ticket[]> {
-    return this.ticketService.findAllByOrderId(orderId);
-  }
-
-  @ApiOperation({
     summary: '[어드민] 해당 주문의 status를 변경한다'
   })
   @ApiResponse({
@@ -162,5 +143,43 @@ export class OrdersController {
     @Param('orderId', OrderIdValidationPipe) orderId: number
   ): Promise<Order> {
     return this.orderService.makeOrderFree(orderId);
+  }
+
+  @ApiOperation({
+    summary: '[어드민] 전체 현황 조회'
+  })
+  @ApiResponse({
+    status: 200,
+    description: '요청 성공시',
+    type: ReportDto
+  })
+  @ApiUnauthorizedResponse({
+    status: 401,
+    description: '어드민이 아닐 경우'
+  })
+  @Roles(Role.Admin)
+  @Get('/report')
+  getReport(): Promise<ReportDto> {
+    return this.orderService.getReport();
+  }
+
+  @ApiOperation({
+    summary: '해당 주문에 속한 티켓 목록을 불러온다'
+  })
+  @ApiResponse({
+    status: 200,
+    description: '요청 성공시',
+    type: Ticket,
+    isArray: true
+  })
+  @ApiUnauthorizedResponse({
+    status: 401,
+    description: 'AccessToken이 없을 경우'
+  })
+  @Get('/:orderId')
+  getTicketListByOrderId(
+    @Param('orderId', OrderIdValidationPipe) orderId: number
+  ): Promise<Ticket[]> {
+    return this.ticketService.findAllByOrderId(orderId);
   }
 }

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -143,4 +143,24 @@ export class OrdersController {
     console.log(typeof updateOrderStatusDto);
     return this.orderService.updateOrderStatus(updateOrderStatusDto, admin);
   }
+
+  @ApiOperation({
+    summary: '[어드민] 해당 주문을 공짜로 변경한다'
+  })
+  @ApiResponse({
+    status: 200,
+    description: '요청 성공시',
+    type: Order
+  })
+  @ApiUnauthorizedResponse({
+    status: 401,
+    description: '어드민이 아닐 경우'
+  })
+  @Roles(Role.Admin)
+  @Patch('/free/:orderId')
+  makeOrderFree(
+    @Param('orderId', OrderIdValidationPipe) orderId: number
+  ): Promise<Order> {
+    return this.orderService.makeOrderFree(orderId);
+  }
 }

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -28,11 +28,15 @@ import { OrderFindDto } from './dtos/order-find.dto';
 import { PageOptionsDto } from 'src/common/dtos/page/page-options.dto';
 import { PageDto } from 'src/common/dtos/page/page.dto';
 import { UpdateOrderStatusDto } from './dtos/update-order-status.dto';
+import { OrderReportDto } from './dtos/order-report.dto';
+import { ReportDto } from './dtos/report.dto';
+import { TicketReportDto } from './dtos/ticket-report.dto';
 
 @Injectable()
 export class OrdersService {
   constructor(
     private orderRepository: OrderRepository,
+    private ticketRepository: TicketRepository,
     private ticketService: TicketsService,
     private dataSource: DataSource,
     private queueService: QueueService
@@ -222,5 +226,16 @@ export class OrdersService {
     order.isFree = true;
     await this.orderRepository.saveOrder(order);
     return order;
+  }
+
+  //전체 현황 조회
+  async getReport(): Promise<ReportDto> {
+    const report = {
+      orderReport: await this.orderRepository.getOrderReport(),
+      ticketReport: await this.ticketRepository.getTicketReport(),
+      enterReport: await this.ticketRepository.getEnterReport(),
+      income: await this.orderRepository.getIncome()
+    };
+    return report;
   }
 }

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -215,4 +215,12 @@ export class OrdersService {
       await queryRunner.release();
     }
   }
+
+  async makeOrderFree(orderId: number): Promise<Order> {
+    // orderId로 주문 찾기
+    const order = await this.orderRepository.findById(orderId);
+    order.isFree = true;
+    await this.orderRepository.saveOrder(order);
+    return order;
+  }
 }

--- a/src/tickets/tickets.controller.ts
+++ b/src/tickets/tickets.controller.ts
@@ -99,7 +99,7 @@ export class TicketsController {
   // @ApiPaginatedDto({ model: Ticket, description: '페이지네이션' })
   @SuccessResponse(HttpStatus.OK, [
     {
-      model: PageDto<Ticket>,
+      model: PageDto,
       exampleDescription: '페이지가 끝일때',
       exampleTitle: '페이지가 끝일때',
       generic: Ticket,
@@ -108,7 +108,7 @@ export class TicketsController {
       }
     },
     {
-      model: PageDto<Ticket>,
+      model: PageDto,
       exampleDescription: '예시',
       exampleTitle: '예시',
       generic: Ticket

--- a/src/tickets/tickets.module.ts
+++ b/src/tickets/tickets.module.ts
@@ -25,7 +25,7 @@ import { TicketsService } from './tickets.service';
       useValue: new Logger('TicketService')
     }
   ],
-  exports: [TicketsService],
+  exports: [TicketsService, TicketRepository],
   controllers: [TicketsController]
 })
 export class TicketsModule {}


### PR DESCRIPTION
## 📝 PR Summary

1. 관리자 권한으로 주문의 isFree를 true로 변경하는 기능

2. 관리자 페이지 전체 현황 조회

<주문관련>
주문 세가지 상태 현황

<티켓관련>
링크발급된 총티켓수,
입금확인된 티켓 수

<입장관련>
입장한 티켓 수,
아직 입장 안한 티켓 수 (입장가능 기준)

판매대금
입금확인 된 주문의 가격합(공짜티켓 제외)


#### 🌲 Working Branch

feature/order

#### 🌲 TODOs

- [x]  주문 공짜 변경
- [x]  주문관련
- [x]  티켓관련
- [x]  입장관련
- [x]  판매대금

### Related Issues

#82 #83 

