### PR TITLE
:rocket: feat(ticket): 티켓 개수 반환 로직, NoAuth 데코레이터 추가 #97

### DIFF
--- a/src/auth/guards/AccessToken.guard.ts
+++ b/src/auth/guards/AccessToken.guard.ts
@@ -20,6 +20,11 @@ export class AccessTokenGuard implements CanActivate {
   canActivate(
     context: ExecutionContext
   ): boolean | Promise<boolean> | Observable<boolean> {
+    //@NoAuth 사용시 해당 부분에서 AccessTokenGuard 사용 해제시킴
+    const noAuth = this.reflector.get<boolean>('no-auth', context.getHandler())
+    if (noAuth) {
+      return true;
+    }
     const request = context.switchToHttp().getRequest();
     return this.validateRequest(request, context);
   }

--- a/src/auth/guards/NoAuth.guard.ts
+++ b/src/auth/guards/NoAuth.guard.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common'
+
+/** AccessTokenGuard 가 포함된 controller 내부에서
+ * AccessToken 없이 접근할 수 있도록 해주는 데코레이터입니다 */
+export const NoAuth = () => SetMetadata('no-auth', true)

--- a/src/database/repositories/ticket.repository.ts
+++ b/src/database/repositories/ticket.repository.ts
@@ -147,6 +147,12 @@ export class TicketRepository {
       .getMany();
   }
 
+
+  /** DB에 저장된 티켓의 개수를 반환한다 */
+  async countTicket(): Promise<number> {
+    return await this.ticketRepository.count();
+  }
+
   /**
    * 해당 티켓을 저장한다
    * @param ticket 저장할 티켓

--- a/src/tickets/dtos/ticket-count.dto.ts
+++ b/src/tickets/dtos/ticket-count.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { IsNumber } from 'class-validator';
+
+/** /tickets/count에 대한 Swagger 응답을 위한 dto 입니다 */
+export class TicketCountDto {
+  @ApiProperty({
+    description: 'DB에 저장된 티켓의 총 개수',
+  })
+  @IsNumber()
+  @Expose()
+  readonly count: number;
+}

--- a/src/tickets/tickets.controller.ts
+++ b/src/tickets/tickets.controller.ts
@@ -34,6 +34,8 @@ import { TicketFindDto } from './dtos/ticket-find.dto';
 import { UpdateTicketStatusDto } from './dtos/update-ticket-status.dto';
 import { SuccessResponse } from 'src/common/decorators/SuccessResponse.decorator';
 import { PageDto } from 'src/common/dtos/page/page.dto';
+import { NoAuth } from 'src/auth/guards/NoAuth.guard';
+import { TicketCountDto } from './dtos/ticket-count.dto';
 
 @ApiTags('tickets')
 @ApiBearerAuth('accessToken')
@@ -142,6 +144,21 @@ export class TicketsController {
   }
 
   @ApiOperation({
+    summary: '[랜딩페이지] 티켓 개수를 반환한다'
+  })
+  @ApiResponse({
+    status: 200,
+    description: '요청 성공시',
+    type: TicketCountDto
+  })
+  @NoAuth()
+  @Get('/count')
+  async getTicketCount() {
+    const count = await this.ticketService.countTicket();
+    return { count: count };
+  }
+
+  @ApiOperation({
     summary: '해당 uuid를 포함하는 티켓을 가져온다, req.user 필요'
   })
   @ApiResponse({
@@ -221,7 +238,7 @@ export class TicketsController {
     description: '어드민이 아닐 경우'
   })
   @Roles(Role.Admin)
-  @Delete('/delete/:uuid')
+  @Delete('/:uuid/delete')
   deleteTicketByUuid(@Param('uuid') ticketUuid: string) {
     return this.ticketService.deleteTicketByUuid(ticketUuid);
   }

--- a/src/tickets/tickets.service.ts
+++ b/src/tickets/tickets.service.ts
@@ -50,7 +50,7 @@ export class TicketsService {
 
     //어드민이거나 Ticket.user.id === user.id 일때만 리턴
     if (ticket.user.id !== user.id && user.role !== Role.Admin) {
-      throw new UnauthorizedException('해등 티켓에 대한 접근 권한이 없습니다');
+      throw new UnauthorizedException('해당 티켓에 대한 접근 권한이 없습니다');
     }
 
     return ticket;
@@ -86,6 +86,10 @@ export class TicketsService {
       ticketFindDto,
       pageOptionsDto
     );
+  }
+
+  async countTicket(): Promise<number> {
+    return await this.ticketRepository.countTicket();
   }
 
   /**


### PR DESCRIPTION
## 📝 PR Summary

<!-- 기능 추가 관련 제목 -->
랜딩 페이지 전용 티켓 개수 반환 로직 추가 및 NoAuth 데코레이터 추가

#### 🌲 Working Branch

<!-- 예시) hotfix/price_comma -->
feature/ticket

#### 🌲 TODOs

<!-- 예시) 작업내용  -->
- 컨트롤러 url 할당
- 서비스 구현
- 레포지토리에서 개수 조회 구현
- NoAuth 데코레이터 추가 
- delete 메서드 RESTful 한 url로 변경
- 에러 메세지 오타 수정

### Related Issues

<!-- 예시)  #1 -->
#97 
